### PR TITLE
HGI-7375 fix too many query logs

### DIFF
--- a/tap_shopify_beta/client.py
+++ b/tap_shopify_beta/client.py
@@ -82,7 +82,7 @@ class shopifyStream(GraphQLStream):
             "query": (" ".join([line.strip() for line in query.splitlines()])),
             "variables": params,
         }
-        self.logger.info(f"Attempting request with variables {params} and query: {request_data['query']}")
+        # self.logger.info(f"Attempting request with variables {params} and query: {request_data['query']}")
         return request_data
 
     def get_field_query(self, field_name: str, schema: dict, is_paginated: bool = False, page_size: int = None) -> str:

--- a/tap_shopify_beta/client_gql.py
+++ b/tap_shopify_beta/client_gql.py
@@ -4,6 +4,7 @@ from time import sleep
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import requests
+import urllib3
 from backports.cached_property import cached_property
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.streams import GraphQLStream
@@ -249,7 +250,8 @@ class shopifyGqlStream(shopifyStream):
         # Add GraphQLInternalServerError to the decorator
         decorated_request = backoff.on_exception(
             self.backoff_wait_generator,
-            (RetriableAPIError, requests.exceptions.ReadTimeout, GraphQLInternalServerError),
+            (RetriableAPIError, GraphQLInternalServerError,
+             requests.exceptions.RequestException, urllib3.exceptions.HTTPError),
             max_tries=self.backoff_max_tries,
             on_backoff=self.backoff_handler,
         )(self._request)

--- a/tap_shopify_beta/streams.py
+++ b/tap_shopify_beta/streams.py
@@ -512,7 +512,7 @@ class OrdersStream(DynamicStream):
             "query": (" ".join([line.strip() for line in query.splitlines()])),
             "variables": params,
         }
-        self.logger.info(f"Attempting request with variables {params} and query: {request_data['query']}")
+        # self.logger.info(f"Attempting request with variables {params} and query: {request_data['query']}")
         return request_data
 
 class ShopStream(shopifyGqlStream):


### PR DESCRIPTION
- Removed graphql queries logs that were making the logs too big
- broaden the exceptions caught by the backoff