### PR TITLE
Fix Shopify date filters to include UTC timezone

### DIFF
--- a/tap_shopify_beta/client_bulk.py
+++ b/tap_shopify_beta/client_bulk.py
@@ -10,6 +10,7 @@ import simplejson
 from hotglue_singer_sdk.helpers.jsonpath import extract_jsonpath
 
 from tap_shopify_beta.client import shopifyStream
+from tap_shopify_beta.shopify_dates import to_shopify_utc
 import re
 
 
@@ -83,12 +84,12 @@ class shopifyBulkStream(shopifyStream):
         if self.replication_key:
             self.start_date = self.start_date or self.get_starting_timestamp({})
             if self.start_date:
-                date = self.start_date.strftime("%Y-%m-%dT%H:%M:%S")
+                date = to_shopify_utc(self.start_date)
                 self.end_date = self.start_date + timedelta(days=1)
                 config_end_date = self.config.get("end_date")
                 if config_end_date and self.end_date > parse(config_end_date):
                     self.end_date = parse(config_end_date)
-                end_str = self.end_date.strftime("%Y-%m-%dT%H:%M:%S")
+                end_str = to_shopify_utc(self.end_date)
                 query = f'(query: "updated_at:>\'{date}\' AND updated_at:<=\'{end_str}\'")'
             return query
         return ""

--- a/tap_shopify_beta/client_gql.py
+++ b/tap_shopify_beta/client_gql.py
@@ -22,6 +22,15 @@ import threading
 from pendulum import parse
 
 
+def to_shopify_utc(dt):
+    """Render a datetime as an explicit UTC RFC3339 bound for Shopify search."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=pytz.UTC)
+    else:
+        dt = dt.astimezone(pytz.UTC)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class GraphQLInternalServerError(RetriableAPIError):
     """Error raised when Shopify returns an internal server error in the GraphQL response."""
     pass
@@ -185,33 +194,36 @@ class shopifyGqlStream(shopifyStream):
             # fetch data in monthly chunks
             if self.config.get(f"sync_{self.name}_monthly"):
                 start_date = self.start_date or self.get_starting_timestamp(context)
-                date = start_date.strftime("%Y-%m-%dT%H:%M:%S")
+                date = to_shopify_utc(start_date)
                 date_filter = f"updated_at:>'{date}'"
                 self.start_date = start_date
                 self.end_date = start_date + relativedelta(months=1)
                 config_end_date = self.config.get("end_date")
                 if config_end_date and self.end_date > parse(config_end_date):
                     self.end_date = parse(config_end_date)
-                end_date = self.end_date.strftime("%Y-%m-%dT%H:%M:%S")
+                end_date = to_shopify_utc(self.end_date)
                 date_filter = f"{date_filter} AND updated_at:<='{end_date}'"
                 params["filter"] = date_filter
 
             elif context and context.get("date_range"):
-                start_date = context['date_range']['start_date'].strftime("%Y-%m-%dT%H:%M:%S")
+                start_date = to_shopify_utc(context['date_range']['start_date'])
                 date_filter = f"updated_at:>'{start_date}'"
                 end_date = context['date_range'].get('end_date')
                 if end_date:
-                    end_date = end_date.strftime("%Y-%m-%dT%H:%M:%S")
+                    end_date = to_shopify_utc(end_date)
                     date_filter = f"{date_filter} AND updated_at:<='{end_date}'"
                 params["filter"] = date_filter
 
             else:
                 start_date = self.start_date or self.get_starting_timestamp(context)
                 if start_date:
-                    date_filter = f"updated_at:>'{start_date.strftime('%Y-%m-%dT%H:%M:%S')}'"
+                    date_filter = f"updated_at:>'{to_shopify_utc(start_date)}'"
                     config_end_date = self.config.get("end_date")
                     if config_end_date:
-                        date_filter = f"{date_filter} AND updated_at:<='{parse(config_end_date).strftime('%Y-%m-%dT%H:%M:%S')}'"
+                        date_filter = (
+                            f"{date_filter} AND "
+                            f"updated_at:<='{to_shopify_utc(parse(config_end_date))}'"
+                        )
                     params["filter"] = date_filter
         if self.single_object_params:
             params = self.single_object_params(context)

--- a/tap_shopify_beta/client_gql.py
+++ b/tap_shopify_beta/client_gql.py
@@ -20,15 +20,7 @@ import concurrent.futures
 import queue
 import threading
 from pendulum import parse
-
-
-def to_shopify_utc(dt):
-    """Render a datetime as an explicit UTC RFC3339 bound for Shopify search."""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=pytz.UTC)
-    else:
-        dt = dt.astimezone(pytz.UTC)
-    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+from tap_shopify_beta.shopify_dates import to_shopify_utc
 
 
 class GraphQLInternalServerError(RetriableAPIError):

--- a/tap_shopify_beta/client_rest.py
+++ b/tap_shopify_beta/client_rest.py
@@ -10,6 +10,8 @@ import backoff
 from hotglue_singer_sdk.exceptions import RetriableAPIError
 import http.client
 
+from tap_shopify_beta.shopify_dates import to_shopify_utc
+
 
 
 class shopifyRestStream(RESTStream):
@@ -74,10 +76,10 @@ class shopifyRestStream(RESTStream):
         params["limit"] = self.limit
         start_date = self.get_starting_time(context)
         if self.replication_key and start_date:
-            params[f"{self.replication_key}_min"] = start_date.strftime('%Y-%m-%dT%H:%M:%S.%f')
+            params[f"{self.replication_key}_min"] = to_shopify_utc(start_date)
         end_date = self.config.get("end_date")
         if self.replication_key and end_date:
-            params[f"{self.replication_key}_max"] = parse(end_date).strftime('%Y-%m-%dT%H:%M:%S.%f')
+            params[f"{self.replication_key}_max"] = to_shopify_utc(parse(end_date))
         if self.add_params:
             params.update(self.add_params)
         if next_page_token:

--- a/tap_shopify_beta/shopify_dates.py
+++ b/tap_shopify_beta/shopify_dates.py
@@ -1,0 +1,12 @@
+"""Date formatting helpers for Shopify API filters."""
+
+import pytz
+
+
+def to_shopify_utc(dt):
+    """Render a datetime as an explicit UTC RFC3339 bound for Shopify filters."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=pytz.UTC)
+    else:
+        dt = dt.astimezone(pytz.UTC)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tap_shopify_beta/streams.py
+++ b/tap_shopify_beta/streams.py
@@ -11,6 +11,7 @@ from hotglue_singer_sdk import typing as th
 from tap_shopify_beta.client_bulk import shopifyBulkStream
 from tap_shopify_beta.client_gql import shopifyGqlStream, GqlChildStream
 from tap_shopify_beta.client_rest import shopifyRestStream
+from tap_shopify_beta.shopify_dates import to_shopify_utc
 from tap_shopify_beta.types.order_app import OrderAppType
 from tap_shopify_beta.types.channel_information import ChannelInformationType
 from tap_shopify_beta.types.customer_email_marketing_consent_state import CustomerEmailMarketingConsentStateType
@@ -1339,7 +1340,7 @@ class PayoutsStream(shopifyGqlStream):
             start_date = self.start_date or self.get_starting_timestamp(context)
             
             if start_date:
-                start_date = start_date.strftime("%Y-%m-%dT%H:%M:%S")
+                start_date = to_shopify_utc(start_date)
                 params["filter"] = f"issued_at:>'{start_date}'"
 
         return params

--- a/tap_shopify_beta/tests/test_client_gql_date_filters.py
+++ b/tap_shopify_beta/tests/test_client_gql_date_filters.py
@@ -2,11 +2,14 @@
 
 import datetime
 import importlib
+import json
 import sys
 import types
 
 import pendulum
 import pytest
+
+from tap_shopify_beta.shopify_dates import to_shopify_utc
 
 
 def _empty_jsonpath(*args, **kwargs):
@@ -14,7 +17,7 @@ def _empty_jsonpath(*args, **kwargs):
 
 
 @pytest.fixture
-def client_gql(monkeypatch):
+def hotglue_sdk_stubs(monkeypatch):
     client_stub = types.ModuleType("tap_shopify_beta.client")
     client_stub.shopifyStream = object
 
@@ -23,6 +26,25 @@ def client_gql(monkeypatch):
 
     exceptions_stub = types.ModuleType("hotglue_singer_sdk.exceptions")
     exceptions_stub.RetriableAPIError = Exception
+
+    streams_stub = types.ModuleType("hotglue_singer_sdk.streams")
+    streams_rest_stub = types.ModuleType("hotglue_singer_sdk.streams.rest")
+    streams_rest_stub.RESTStream = object
+
+    authenticators_stub = types.ModuleType("hotglue_singer_sdk.authenticators")
+
+    class APIKeyAuthenticator:
+        @classmethod
+        def create_for_stream(cls, *args, **kwargs):
+            return cls()
+
+    authenticators_stub.APIKeyAuthenticator = APIKeyAuthenticator
+
+    auth_stub = types.ModuleType("tap_shopify_beta.auth")
+    auth_stub.ShopifyAuthenticator = object
+    simplejson_stub = types.ModuleType("simplejson")
+    simplejson_stub.JSONDecodeError = json.JSONDecodeError
+    simplejson_stub.loads = json.loads
 
     monkeypatch.setitem(sys.modules, "tap_shopify_beta.client", client_stub)
     monkeypatch.setitem(sys.modules, "hotglue_singer_sdk", types.ModuleType("hotglue_singer_sdk"))
@@ -33,25 +55,57 @@ def client_gql(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.helpers.jsonpath", jsonpath_stub)
     monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.exceptions", exceptions_stub)
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.streams", streams_stub)
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.streams.rest", streams_rest_stub)
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.authenticators", authenticators_stub)
+    monkeypatch.setitem(sys.modules, "tap_shopify_beta.auth", auth_stub)
+    monkeypatch.setitem(sys.modules, "simplejson", simplejson_stub)
+    yield
+    for module_name in (
+        "tap_shopify_beta.client_bulk",
+        "tap_shopify_beta.client_gql",
+        "tap_shopify_beta.client_rest",
+    ):
+        sys.modules.pop(module_name, None)
+
+
+@pytest.fixture
+def client_gql(hotglue_sdk_stubs):
     sys.modules.pop("tap_shopify_beta.client_gql", None)
     module = importlib.import_module("tap_shopify_beta.client_gql")
     yield module
     sys.modules.pop("tap_shopify_beta.client_gql", None)
 
 
-def test_to_shopify_utc_formats_naive_datetime_with_z(client_gql):
+@pytest.fixture
+def client_bulk(hotglue_sdk_stubs):
+    sys.modules.pop("tap_shopify_beta.client_bulk", None)
+    module = importlib.import_module("tap_shopify_beta.client_bulk")
+    yield module
+    sys.modules.pop("tap_shopify_beta.client_bulk", None)
+
+
+@pytest.fixture
+def client_rest(hotglue_sdk_stubs):
+    sys.modules.pop("tap_shopify_beta.client_rest", None)
+    module = importlib.import_module("tap_shopify_beta.client_rest")
+    yield module
+    sys.modules.pop("tap_shopify_beta.client_rest", None)
+
+
+def test_to_shopify_utc_formats_naive_datetime_with_z():
     value = datetime.datetime(2026, 7, 1, 2, 58, 8)
 
-    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+    assert to_shopify_utc(value) == "2026-07-01T02:58:08Z"
 
 
-def test_to_shopify_utc_formats_aware_utc_datetime_with_z(client_gql):
+def test_to_shopify_utc_formats_aware_utc_datetime_with_z():
     value = datetime.datetime(2026, 7, 1, 2, 58, 8, tzinfo=datetime.timezone.utc)
 
-    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+    assert to_shopify_utc(value) == "2026-07-01T02:58:08Z"
 
 
-def test_to_shopify_utc_converts_offset_datetime_to_utc_z(client_gql):
+def test_to_shopify_utc_converts_offset_datetime_to_utc_z():
     value = datetime.datetime(
         2026,
         7,
@@ -62,13 +116,13 @@ def test_to_shopify_utc_converts_offset_datetime_to_utc_z(client_gql):
         tzinfo=datetime.timezone(datetime.timedelta(hours=10)),
     )
 
-    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+    assert to_shopify_utc(value) == "2026-07-01T02:58:08Z"
 
 
-def test_to_shopify_utc_converts_pendulum_datetime_to_utc_z(client_gql):
+def test_to_shopify_utc_converts_pendulum_datetime_to_utc_z():
     value = pendulum.datetime(2026, 7, 1, 12, 58, 8, tz="Australia/Brisbane")
 
-    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+    assert to_shopify_utc(value) == "2026-07-01T02:58:08Z"
 
 
 def test_get_url_params_date_range_filter_uses_utc_z_bounds(client_gql):
@@ -93,3 +147,66 @@ def test_get_url_params_date_range_filter_uses_utc_z_bounds(client_gql):
         "updated_at:>'2026-07-01T12:45:54Z' "
         "AND updated_at:<='2026-07-01T15:33:17Z'"
     )
+
+
+def test_get_url_params_monthly_filter_uses_utc_z_bounds(client_gql):
+    stream = client_gql.shopifyGqlStream.__new__(client_gql.shopifyGqlStream)
+    stream.name = "orders"
+    stream.replication_key = "updatedAt"
+    stream.config = {"sync_orders_monthly": True}
+    stream.start_date = None
+    stream.get_starting_timestamp = lambda context: pendulum.datetime(
+        2026, 7, 1, 12, 45, 54, tz="Australia/Brisbane"
+    )
+
+    params = stream.get_url_params({}, None)
+
+    assert params["filter"] == (
+        "updated_at:>'2026-07-01T02:45:54Z' "
+        "AND updated_at:<='2026-08-01T02:45:54Z'"
+    )
+
+
+def test_get_url_params_plain_incremental_filter_uses_utc_z_bounds(client_gql):
+    stream = client_gql.shopifyGqlStream.__new__(client_gql.shopifyGqlStream)
+    stream.name = "orders"
+    stream.replication_key = "updatedAt"
+    stream.config = {"end_date": "2026-07-01T15:33:17+10:00"}
+    stream.start_date = pendulum.datetime(2026, 7, 1, 12, 45, 54, tz="Australia/Brisbane")
+
+    params = stream.get_url_params({}, None)
+
+    assert params["filter"] == (
+        "updated_at:>'2026-07-01T02:45:54Z' "
+        "AND updated_at:<='2026-07-01T05:33:17Z'"
+    )
+
+
+def test_bulk_filter_uses_utc_z_bounds(client_bulk):
+    stream = client_bulk.shopifyBulkStream.__new__(client_bulk.shopifyBulkStream)
+    stream.replication_key = "updatedAt"
+    stream.start_date = None
+    stream.config = {}
+    stream.get_starting_timestamp = lambda context: pendulum.datetime(
+        2026, 7, 1, 12, 58, 8, tz="Australia/Brisbane"
+    )
+
+    assert stream.filters == (
+        "(query: \"updated_at:>'2026-07-01T02:58:08Z' "
+        "AND updated_at:<='2026-07-02T02:58:08Z'\")"
+    )
+
+
+def test_rest_params_use_utc_z_bounds(client_rest):
+    stream = client_rest.shopifyRestStream.__new__(client_rest.shopifyRestStream)
+    stream.replication_key = "updated_at"
+    stream.config = {"end_date": "2026-07-01T15:33:17+10:00"}
+    stream.add_params = None
+    stream.get_starting_time = lambda context: pendulum.datetime(
+        2026, 7, 1, 12, 45, 54, tz="Australia/Brisbane"
+    )
+
+    params = stream.get_url_params({}, None)
+
+    assert params["updated_at_min"] == "2026-07-01T02:45:54Z"
+    assert params["updated_at_max"] == "2026-07-01T05:33:17Z"

--- a/tap_shopify_beta/tests/test_client_gql_date_filters.py
+++ b/tap_shopify_beta/tests/test_client_gql_date_filters.py
@@ -1,0 +1,95 @@
+"""Tests for Shopify GraphQL updated_at search filter bounds."""
+
+import datetime
+import importlib
+import sys
+import types
+
+import pendulum
+import pytest
+
+
+def _empty_jsonpath(*args, **kwargs):
+    return iter(())
+
+
+@pytest.fixture
+def client_gql(monkeypatch):
+    client_stub = types.ModuleType("tap_shopify_beta.client")
+    client_stub.shopifyStream = object
+
+    jsonpath_stub = types.ModuleType("hotglue_singer_sdk.helpers.jsonpath")
+    jsonpath_stub.extract_jsonpath = _empty_jsonpath
+
+    exceptions_stub = types.ModuleType("hotglue_singer_sdk.exceptions")
+    exceptions_stub.RetriableAPIError = Exception
+
+    monkeypatch.setitem(sys.modules, "tap_shopify_beta.client", client_stub)
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk", types.ModuleType("hotglue_singer_sdk"))
+    monkeypatch.setitem(
+        sys.modules,
+        "hotglue_singer_sdk.helpers",
+        types.ModuleType("hotglue_singer_sdk.helpers"),
+    )
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.helpers.jsonpath", jsonpath_stub)
+    monkeypatch.setitem(sys.modules, "hotglue_singer_sdk.exceptions", exceptions_stub)
+    sys.modules.pop("tap_shopify_beta.client_gql", None)
+    module = importlib.import_module("tap_shopify_beta.client_gql")
+    yield module
+    sys.modules.pop("tap_shopify_beta.client_gql", None)
+
+
+def test_to_shopify_utc_formats_naive_datetime_with_z(client_gql):
+    value = datetime.datetime(2026, 7, 1, 2, 58, 8)
+
+    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+
+
+def test_to_shopify_utc_formats_aware_utc_datetime_with_z(client_gql):
+    value = datetime.datetime(2026, 7, 1, 2, 58, 8, tzinfo=datetime.timezone.utc)
+
+    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+
+
+def test_to_shopify_utc_converts_offset_datetime_to_utc_z(client_gql):
+    value = datetime.datetime(
+        2026,
+        7,
+        1,
+        12,
+        58,
+        8,
+        tzinfo=datetime.timezone(datetime.timedelta(hours=10)),
+    )
+
+    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+
+
+def test_to_shopify_utc_converts_pendulum_datetime_to_utc_z(client_gql):
+    value = pendulum.datetime(2026, 7, 1, 12, 58, 8, tz="Australia/Brisbane")
+
+    assert client_gql.to_shopify_utc(value) == "2026-07-01T02:58:08Z"
+
+
+def test_get_url_params_date_range_filter_uses_utc_z_bounds(client_gql):
+    stream = client_gql.shopifyGqlStream.__new__(client_gql.shopifyGqlStream)
+    stream.name = "orders"
+    stream.replication_key = "updatedAt"
+    stream.config = {}
+    context = {
+        "date_range": {
+            "start_date": datetime.datetime(
+                2026, 7, 1, 12, 45, 54, tzinfo=datetime.timezone.utc
+            ),
+            "end_date": datetime.datetime(
+                2026, 7, 1, 15, 33, 17, tzinfo=datetime.timezone.utc
+            ),
+        }
+    }
+
+    params = stream.get_url_params(context, None)
+
+    assert params["filter"] == (
+        "updated_at:>'2026-07-01T12:45:54Z' "
+        "AND updated_at:<='2026-07-01T15:33:17Z'"
+    )


### PR DESCRIPTION
## Summary

Fix Shopify date filters so every incremental bound is emitted as explicit UTC with a trailing `Z`.

Shopify interprets offset-less date search bounds as the shop's local timezone. For non-UTC shops, the current tap builds a UTC datetime window but sends it without an offset, shifting the effective Shopify search window by the shop's UTC offset. That can drop recently-updated records until the offset window catches up.

## Evidence

Controlled Shopify test order:
- `updatedAt = 2026-07-01T02:58:08Z`
- shop timezone: Brisbane UTC+10

Direct Shopify GraphQL A/B over the same two-minute window:
- bare query `updated_at:>'2026-07-01T02:57:08' AND updated_at:<='2026-07-01T02:59:08'` returned 0 orders.
- UTC query `updated_at:>'2026-07-01T02:57:08Z' AND updated_at:<='2026-07-01T02:59:08Z'` returned the test order.

Hotglue job evidence:
- a source job emitted the offset-less Shopify search filter `updated_at:>'2026-07-01T02:45:54' AND updated_at:<='2026-07-01T05:33:17'`.
- the test order's `updatedAt` value, `2026-07-01T02:58:08Z`, is inside that UTC window.
- the tap emitted `orders.record_count = 0`, so downstream sync consumers received no order payload.

## Changes

- Added a shared UTC formatter helper for Shopify search/filter bounds.
- Routed GraphQL `updated_at` start/end bounds in `get_url_params` through that helper:
  - monthly chunk start/end
  - concurrent `date_range` start/end
  - plain incremental start/config `end_date`
- Routed sibling Shopify date filters through the same helper:
  - Bulk GraphQL `updated_at` start/end
  - REST `{replication_key}_min` / `{replication_key}_max`
  - payouts GraphQL `issued_at`
- Left `get_concurrent_params` future-end capping unchanged.
- Added focused tests for naive datetimes, UTC-aware datetimes, offset-aware datetimes, GraphQL filter construction, bulk filter construction, and REST params.

## Validation

- `python -m pytest tap_shopify_beta/tests/test_client_gql_date_filters.py`
- `ruff check .`

Note: a normal local `tox -e ruff` run could not complete on my workstation because this public checkout depends on Hotglue's private `hotglue-singer-sdk` package and the host Python versions available are 3.12/3.14 while the repo declares `<3.11`. The configured ruff command was run directly and passed.
