### PR TITLE
Add variant weight to the variants stream (inventoryItem.measurement.weight)

### DIFF
--- a/tap_shopify_beta/streams.py
+++ b/tap_shopify_beta/streams.py
@@ -161,7 +161,15 @@ class VariantsStream(DynamicStream):
                 th.Property("id", th.StringType), th.Property("altText", th.StringType)
             ),
         ),
-        th.Property("inventoryItem", th.ObjectType(th.Property("id", th.StringType))),
+        th.Property("inventoryItem", th.ObjectType(
+            th.Property("id", th.StringType),
+            th.Property("measurement", th.ObjectType(
+                th.Property("weight", th.ObjectType(
+                    th.Property("unit", th.StringType),
+                    th.Property("value", th.NumberType),
+                )),
+            )),
+        )),
         th.Property("inventoryPolicy", th.StringType),
         th.Property("inventoryQuantity", th.IntegerType),
         th.Property("legacyResourceId", th.StringType),


### PR DESCRIPTION
## What
Expose Shopify variant **weight** on the `variants` stream by expanding `inventoryItem`
(currently `{ id }`) to include `measurement.weight { unit, value }`.

## Why
Shopify stores per-variant weight at `ProductVariant.inventoryItem.measurement.weight { unit value }`
(the older top-level `weight` / `weightUnit` are deprecated). The `variants` stream currently drops
it, so variant weight can't be read from Shopify. This blocks the Fishbowl Shopify integration from
importing product weight (our tracking ref: ADV-5640).

## Change
Schema-only — the GraphQL selection is derived from the stream schema, so adding the nested property
is sufficient. The `products` stream is unchanged (weight is variant-level, not product-level).

## Notes
- `unit` is the Shopify `WeightUnit` enum (GRAMS / KILOGRAMS / OUNCES / POUNDS); `value` is a Float.
- Companion change on `target-shopify-v2` handles the write side. We'd welcome guidance on how the
  unified schema should surface this to consumers — we're proposing flat `weight` (Float) +
  `weight_unit` (WeightUnit enum) on the unified variant record, symmetric with the write side.
